### PR TITLE
Add Go Modules and image.Paletted fast path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mattn/go-sixel
+
+go 1.15
+
+require github.com/soniakeys/quant v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=
+github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=


### PR DESCRIPTION
This pull request adds:

- Go Modules support, because Go 1.16 now sets it to be the default.
- `*image.Paletted` fast path if the number of palettes checks out.
- `Encoder.Colors` to allow an arbitrary number of colors be quantized. The default is still `255`.